### PR TITLE
add support for gcp

### DIFF
--- a/charts/continuous-load/charts/k6/templates/podmonitor.yaml
+++ b/charts/continuous-load/charts/k6/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.promOperator "coreos" -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -49,3 +50,44 @@ spec:
       targetLabel: node_ip
       replacement: $1
       action: replace
+{{- end -}}
+{{- if eq .Values.global.promOperator "googleapis" -}}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: k6
+  labels:
+    app: k6
+spec:
+  selector:
+    matchExpressions:
+      - key: "app.kubernetes.io/name"
+        operator: In
+        values: ["k6"]
+  endpoints:
+  - path: /metrics
+    port: http
+    metricRelabeling:
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      action: keep
+      regex: "true"
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: pod_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_host_ip]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_ip
+      replacement: $1
+      action: replace
+{{- end -}}

--- a/charts/continuous-load/charts/k6/templates/prometheus-alerts-k6.yaml
+++ b/charts/continuous-load/charts/k6/templates/prometheus-alerts-k6.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.promOperator "coreos" -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -97,4 +99,4 @@ spec:
           Memory usage percentage: `{{`{{`}} $value | humanize {{`}}`}}`
           Expected <= 90% for 1m
         summary: The container is using more memory than expected.
-  
+{{- end -}}

--- a/charts/continuous-load/templates/continuous-load-dashboard.yaml
+++ b/charts/continuous-load/templates/continuous-load-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled -}}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -7,7 +8,7 @@ spec:
   resyncPeriod: 5m
   instanceSelector:
     matchLabels:
-      dashboards: "grafana"
+      dashboards: {{ .Values.grafanaInstanceLabel }}
   json: >-
     {
       "annotations": {
@@ -588,10 +589,10 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by(name, status) (rate(k6_http_reqs{\n    namespace=\"continuous-load\"\n}[$__rate_interval])) > 0",
+              "expr": "sum by(name, status) (rate(k6_http_reqs{\n    namespace=\"{{ .Release.Namespace }}\"\n}[$__rate_interval])) > 0",
               "hide": false,
               "interval": "",
-              "legendFormat": "Response  {{ status }}",
+              "legendFormat": "Response  {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"
@@ -684,10 +685,10 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(k6_http_reqs{status=\"200\", namespace=\"continuous-load\"}[${timespan}]))/sum(rate(k6_http_reqs{namespace=\"continuous-load\"}[${timespan}])) * 100",
+              "expr": "sum(rate(k6_http_reqs{status=\"200\", namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))/sum(rate(k6_http_reqs{namespace=\"{{ .Release.Namespace }}\"}[${timespan}])) * 100",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{value }}",
+              "legendFormat": "{{`{{ value }}`}}",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"
@@ -779,7 +780,7 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "histogram_quantile(0.95, \nsum(rate(k6_http_req_duration_bucket{namespace=\"continuous-load\"}[${timespan}]))by (le))",
+              "expr": "histogram_quantile(0.95, \nsum(rate(k6_http_req_duration_bucket{namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P95",
@@ -790,7 +791,7 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "histogram_quantile(0.80, \nsum(rate(k6_http_req_duration_bucket{namespace=\"continuous-load\"}[${timespan}]))by (le))",
+              "expr": "histogram_quantile(0.80, \nsum(rate(k6_http_req_duration_bucket{namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P80",
@@ -800,7 +801,7 @@ spec:
             },
             {
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, \nsum(rate(k6_http_req_duration_bucket{namespace=\"continuous-load\"}[${timespan}]))by (le))",
+              "expr": "histogram_quantile(0.50, \nsum(rate(k6_http_req_duration_bucket{namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))by (le))",
               "hide": false,
               "legendFormat": "P50",
               "range": true,
@@ -808,7 +809,7 @@ spec:
             },
             {
               "editorMode": "code",
-              "expr": "histogram_quantile(0.10, \nsum(rate(k6_http_req_duration_bucket{namespace=\"continuous-load\"}[${timespan}]))by (le))",
+              "expr": "histogram_quantile(0.10, \nsum(rate(k6_http_req_duration_bucket{namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))by (le))",
               "hide": false,
               "legendFormat": "P10",
               "range": true,
@@ -901,7 +902,7 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "histogram_quantile(0.99, \nsum(rate(k6_http_req_duration_bucket{namespace=\"continuous-load\"}[${timespan}]))by (le))",
+              "expr": "histogram_quantile(0.99, \nsum(rate(k6_http_req_duration_bucket{namespace=\"{{ .Release.Namespace }}\"}[${timespan}]))by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "P99",
@@ -1009,10 +1010,10 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by(path, method, status) (rate(http_request_duration_seconds_count{\n    namespace=\"continuous-load\", path=\"status\"\n}[$__rate_interval])) > 0",
+              "expr": "sum by(path, method, status) (rate(http_request_duration_seconds_count{\n    namespace=\"{{ .Release.Namespace }}\", path=\"status\"\n}[$__rate_interval])) > 0",
               "hide": false,
               "interval": "",
-              "legendFormat": "Response  {{ status }}",
+              "legendFormat": "Response  {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"
@@ -1020,7 +1021,7 @@ spec:
             {
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(http_request_duration_seconds_count{namespace=\"continuous-load\",  path=\"status\"}[$__rate_interval]))",
+              "expr": "sum(rate(http_request_duration_seconds_count{namespace=\"{{ .Release.Namespace }}\",  path=\"status\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "TOTAL",
@@ -1115,10 +1116,10 @@ spec:
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum by (path, method)(rate(http_request_duration_seconds_count{status=\"200\", namespace=\"continuous-load\",  path=\"status\"}[${timespan}]))/sum by (path, method)(rate(http_request_duration_seconds_count{namespace=\"continuous-load\",  path=\"status\"}[${timespan}])) * 100",
+              "expr": "sum by (path, method)(rate(http_request_duration_seconds_count{status=\"200\", namespace=\"{{ .Release.Namespace }}\",  path=\"status\"}[${timespan}]))/sum by (path, method)(rate(http_request_duration_seconds_count{namespace=\"{{ .Release.Namespace }}\",  path=\"status\"}[${timespan}])) * 100",
               "hide": false,
               "interval": "",
-              "legendFormat": "Path: {{path}}",
+              "legendFormat": "Path: {{`{{ path }}`}}",
               "queryType": "randomWalk",
               "range": true,
               "refId": "A"
@@ -1209,37 +1210,37 @@ spec:
           "targets": [
             {
               "exemplar": false,
-              "expr": "histogram_quantile(0.95, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"continuous-load\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
+              "expr": "histogram_quantile(0.95, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"{{ .Release.Namespace }}\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
               "hide": false,
               "interval": "",
-              "legendFormat": "P95 Path: {{path}} Status: {{status}}",
+              "legendFormat": "P95 Path: {{`{{ path }}`}} Status: {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "refId": "B"
             },
             {
               "exemplar": false,
-              "expr": "histogram_quantile(0.80, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"continuous-load\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
+              "expr": "histogram_quantile(0.80, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"{{ .Release.Namespace }}\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
               "hide": false,
               "interval": "",
-              "legendFormat": "P80 Path: {{path}} Status: {{status}}",
+              "legendFormat": "P80 Path: {{`{{ path }}`}} Status: {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "refId": "C"
             },
             {
               "exemplar": false,
-              "expr": "histogram_quantile(0.50, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"continuous-load\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
+              "expr": "histogram_quantile(0.50, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"{{ .Release.Namespace }}\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
               "hide": false,
               "interval": "",
-              "legendFormat": "P50 Path: {{path}} Status: {{status}}",
+              "legendFormat": "P50 Path: {{`{{ path }}`}} Status: {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "refId": "D"
             },
             {
               "exemplar": false,
-              "expr": "histogram_quantile(0.10, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"continuous-load\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
+              "expr": "histogram_quantile(0.10, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"{{ .Release.Namespace }}\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
               "hide": false,
               "interval": "",
-              "legendFormat": "P10 Path: {{path}} Status: {{status}}",
+              "legendFormat": "P10 Path: {{`{{ path }}`}} Status: {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "refId": "E"
             }
@@ -1329,10 +1330,10 @@ spec:
           "targets": [
             {
               "exemplar": false,
-              "expr": "histogram_quantile(0.99, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"continuous-load\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
+              "expr": "histogram_quantile(0.99, \nsum(rate(http_request_duration_seconds_bucket{namespace=\"{{ .Release.Namespace }}\", path=\"status\"}[${timespan}])) by (le, path, method, status))",
               "hide": false,
               "interval": "",
-              "legendFormat": "P99 Path: {{path}} Status: {{status}}",
+              "legendFormat": "P99 Path: {{`{{ path }}`}} Status: {{`{{ status }}`}}",
               "queryType": "randomWalk",
               "refId": "A"
             }
@@ -1455,3 +1456,4 @@ spec:
       "version": 3,
       "weekStart": ""
     }
+{{- end -}}

--- a/charts/continuous-load/templates/pod-monitor.yaml
+++ b/charts/continuous-load/templates/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.global.promOperator "coreos" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -13,3 +14,20 @@ spec:
   namespaceSelector:
     matchNames:
     - {{.Release.Namespace}}
+{{- end -}}
+{{- if eq .Values.global.promOperator "googleapis" -}}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: k6-podmonitor
+  labels:
+    release: prometheus
+  namespace: {{.Release.Namespace}}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k6
+  endpoints:
+  - port: http
+{{- end -}}

--- a/charts/continuous-load/templates/service-monitor.yaml
+++ b/charts/continuous-load/templates/service-monitor.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.global.promOperator "coreos" -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -25,3 +27,23 @@ spec:
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
+{{- end -}}
+{{- if eq .Values.global.promOperator "googleapis" -}}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: servicemonitor
+  labels:
+    release: prometheus
+  namespace: {{.Release.Namespace}}
+spec:
+  selector:
+    matchExpressions:
+    - {key: app.kubernetes.io/name, operator: Exists}
+  endpoints:
+  - port: http
+    interval: 15s
+  - port: https
+    interval: 15s
+{{- end -}}

--- a/charts/continuous-load/values.yaml
+++ b/charts/continuous-load/values.yaml
@@ -1,3 +1,13 @@
+global:
+  # -- Configure the Prometheus operator to use.  Valid values are "coreos", "googleapis", "none"
+  promOperator: coreos
+
+# -- Configure the grafana instance that the dashboard will be deploy to
+grafanaInstanceLabel: grafana
+
+dashboard:
+  enabled: true
+
 podinfo:
   # -- Configure the number of replicas of the target service
   replicaCount: "2"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,17 @@
 #!/bin/bash -eu
 
+: "${NAMESPACE:=continuous-load}"
+
 # deploy_continuous_load - deploys the load injector and target application as well as
 # the ServiceMonitor and PodMonitor objects that are used to supply Prometheus with 
 # the scrape configuration.
 # Params:
-#  1) the namespace in which to deploy the monitors
-#  2) the target of the load generator. See https://k6.io/docs/javascript-api/k6-http/params/
+#  1) the target of the load generator. See https://k6.io/docs/javascript-api/k6-http/params/
 #     for info on accepted parameters
-#  3) the number of replicas to run
-#  4) the thresholds for pass/failure. See https://k6.io/docs/using-k6/thresholds/
-#  5) the number of requests per second to run
+#  2) the number of replicas to run
+#  3) the thresholds for pass/failure. See https://k6.io/docs/using-k6/thresholds/
+#  4) the number of requests per second to run
+#  5) the type of Prometheus operator to use.  (coreos, googleapis, none)
 # 
 # This implementation uses the podinfo application, which is able to generate 
 # metrics that are used in the dashboard.
@@ -17,40 +19,27 @@
 # This implementation uses k6 to generate the load.  The parameters are defined 
 # in continuous-load/charts/k6/load.js.
 function deploy_continuous_load() {
-  local namespace="$1"
-  local loadTargetService="$2"
-  local replicas="$3"
-  local thresholds="$4"
-  local reqPerSecond="$5"
+  local loadTargetService="$1"
+  local replicas="$2"
+  local thresholds="$3"
+  local reqPerSecond="$4"
+  local promOperator="$5"
   echo "===> Deploying Continuous Load"
   helm dependency update ./charts/continuous-load
   helm upgrade -install --wait continuous-load \
-  --namespace ${namespace}  \
+  --namespace ${NAMESPACE}  \
   --set "podinfo.replicaCount=${replicas}" \
   --set-json "k6.loadTargetService[0]=${loadTargetService}" \
   --set-json "k6.thresholds=${thresholds}" \
   --set "k6.reqPerSecond=${reqPerSecond}" \
+  --set "global.promOperator=${promOperator}" \
   ./charts/continuous-load/
 }
 
-# deploy_dashboard - deploys the Grafana dashboard for monitoring the health of 
-# the synthetic load.
-# Params:
-#  1) the namespace in which to deploy the dashboard
-# 
-# The json from the Grafana dashboard is saved in continuous-load-dashboard.yaml
-function deploy_dashboard() {
-  local namespace="$1"
-  echo "===> Deploying Dashboard"
-  # Can't put this into a helm chart due to the difficulty in escaping Grafana variables
-  kubectl -n ${namespace} apply -f continuous-load-dashboard.yaml
-}
-
 function main() {
-  local namespace="continuous-load"
   local loadTargetService="{ \
       \"method\": \"GET\", \
-      \"url\": \"http://continuous-load-podinfo.${namespace}.svc.cluster.local:9898/status/200\", \
+      \"url\": \"http://continuous-load-podinfo.${NAMESPACE}.svc.cluster.local:9898/status/200\", \
       \"params\": { 
         \"tags\": { 
           \"type\": \"service\"
@@ -64,8 +53,8 @@ function main() {
     \"http_req_duration\": [\"p(95)<200\"]
   }"
   local reqPerSecond="3"
-  deploy_continuous_load "${namespace}" "${loadTargetService}" "${replicas}" "${thresholds}" "${reqPerSecond}"
-  deploy_dashboard "${namespace}"
+  local promOperator="coreos"
+  deploy_continuous_load "${loadTargetService}" "${replicas}" "${thresholds}" "${reqPerSecond}" "${promOperator}"
   echo "-----------------------------------------"
   echo "-----------------------------------------"
   echo "Components are ready:"
@@ -77,7 +66,7 @@ while getopts 'i' flag; do
   case "${flag}" in
     i)  
       source ./prerequisites.sh
-      namespace="continuous-load"
+      namespace="${NAMESPACE}"
       deploy_monitoring $namespace "http://prometheus-operated.${namespace}.svc.cluster.local:9090"
       ;;
     *) echo "Invalid option: -$flag" ;;


### PR DESCRIPTION
also adds the dashboard into the helm chart (assumes the grafana operator has been installed, but can be disabled if not)